### PR TITLE
Add tests for get_template()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -45,23 +45,25 @@ get_data <- function(id, meta_type) {
 #'
 #' Gets the template synId from the config file.
 #'
-#' @param metadata_type The metadata type, or NA for manifest.
+#' @param metadata_type The metadata type.
 #' @param species The species.
 #' @param assay_type The type of assay.
-#' @return synId for the template in Synapse.
+#' @return synId for the template in Synapse, or `NULL` if template
+#'   not found in config file.
 get_template <- function(metadata_type, species = NA, assay_type = NA) {
+  template <- NULL
   template <- switch(
     metadata_type,
     manifest = config::get("templates")$manifest_template,
     individual = {
-      if (species != "human") {
+      if (!is.na(species) && species != "human") {
         config::get("templates")$individual_templates[["animal"]]
       } else {
         config::get("templates")$individual_templates[[species]]
       }
     },
     biospecimen = {
-      if (species != "drosophila") {
+      if (!is.na(species) && species != "drosophila") {
         config::get("templates")$biospecimen_templates[["general"]]
       } else {
         config::get("templates")$biospecimen_templates[[species]]

--- a/man/get_template.Rd
+++ b/man/get_template.Rd
@@ -7,14 +7,15 @@
 get_template(metadata_type, species = NA, assay_type = NA)
 }
 \arguments{
-\item{metadata_type}{The metadata type, or NA for manifest.}
+\item{metadata_type}{The metadata type.}
 
 \item{species}{The species.}
 
 \item{assay_type}{The type of assay.}
 }
 \value{
-synId for the template in Synapse.
+synId for the template in Synapse, or `NULL` if template
+  not found in config file.
 }
 \description{
 Gets the template synId from the config file.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,42 @@
+context("utils.R")
+
+test_that("get_template returns NULL if template not in config", {
+  res1 <- get_template(metadata_type = NA)
+  res2 <- get_template(metadata_type = "individual")
+  res3 <- get_template(metadata_type = "assay")
+  expect_null(res1)
+  expect_null(res2)
+  expect_null(res3)
+})
+
+test_that("get_template returns correct default template", {
+  res1 <- get_template(
+    metadata_type = "individual",
+    species = "human"
+  )
+  res2 <- get_template(
+    metadata_type = "individual",
+    species = "drosophila"
+  )
+  res3 <- get_template(
+    metadata_type = "biospecimen",
+    species = "drosophila"
+  )
+  res4 <- get_template(
+    metadata_type = "biospecimen",
+    species = "human"
+  )
+  res5 <- get_template(
+    metadata_type = "assay",
+    assay = "rnaSeq"
+  )
+  res6 <- get_template(
+    metadata_type = "manifest"
+  )
+  expect_equal(res1, "syn12973254")
+  expect_equal(res2, "syn12973253")
+  expect_equal(res3, "syn20673251")
+  expect_equal(res4, "syn12973252")
+  expect_equal(res5, "syn12973256")
+  expect_equal(res6, "syn20820080")
+})


### PR DESCRIPTION
Currently not sure what the best way to test the other two functions in utils.R would be since one is technically a synapser wrapper with little added, and the other downloads files from Synapse. For this one, I just added tests for get_template() since that seemed reasonable right now.