### PR TITLE
Test get_all_file_templates() and update get_template()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -48,10 +48,12 @@ get_data <- function(id, meta_type) {
 #' @param metadata_type The metadata type.
 #' @param species The species.
 #' @param assay_type The type of assay.
-#' @return synId for the template in Synapse, or `NULL` if template
-#'   not found in config file.
+#' @return synId for the template in Synapse, `NULL` if template
+#'   not found in config file, or `NA` if `metadata_type` is `NA`.
 get_template <- function(metadata_type, species = NA, assay_type = NA) {
-  template <- NULL
+  if (is.na(metadata_type)) {
+    return(NA)
+  }
   template <- switch(
     metadata_type,
     manifest = config::get("templates")$manifest_template,

--- a/man/get_template.Rd
+++ b/man/get_template.Rd
@@ -14,8 +14,8 @@ get_template(metadata_type, species = NA, assay_type = NA)
 \item{assay_type}{The type of assay.}
 }
 \value{
-synId for the template in Synapse, or `NULL` if template
-  not found in config file.
+synId for the template in Synapse, `NULL` if template
+  not found in config file, or `NA` if `metadata_type` is `NA`.
 }
 \description{
 Gets the template synId from the config file.

--- a/tests/testthat/test-get-all-file-data.R
+++ b/tests/testthat/test-get-all-file-data.R
@@ -1,0 +1,19 @@
+context("get-all-file-data.R")
+
+data <- tibble::tribble(
+  ~metadataType, ~species, ~assay,
+  "manifest", NA, NA,
+  "individual", "human", NA,
+  "biospecimen", "human", NA,
+  "assay", "human", "rnaSeq",
+  NA, NA, NA
+)
+
+test_that("get_all_file_templates gets templates for all valid rows", {
+  res <- get_all_file_templates(data)
+  expect_equal(res$template[1], "syn20820080")
+  expect_equal(res$template[2], "syn12973254")
+  expect_equal(res$template[3], "syn12973252")
+  expect_equal(res$template[4], "syn12973256")
+  expect_true(is.na(res$template[5]))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,12 +1,15 @@
 context("utils.R")
 
 test_that("get_template returns NULL if template not in config", {
-  res1 <- get_template(metadata_type = NA)
-  res2 <- get_template(metadata_type = "individual")
-  res3 <- get_template(metadata_type = "assay")
+  res1 <- get_template(metadata_type = "individual")
+  res2 <- get_template(metadata_type = "assay")
   expect_null(res1)
   expect_null(res2)
-  expect_null(res3)
+})
+
+test_that("get_template returns NA if metadata_type is NA", {
+  res1 <- get_template(metadata_type = NA)
+  expect_equal(res1, NA)
 })
 
 test_that("get_template returns correct default template", {


### PR DESCRIPTION
Update get_template() because (from commit history):

> There may be times where the documentation rows haven't been filtered out of the fileview that's passed to get_all_file_templates(). In this case, the metadataType will be NA and there would be a problem with trying to assign NULL to the column. Instead, just pass back NA. In terms of fileviews, there should not be a NULL metadataType that is passed in, only NA or the exact type.

Add tests for get_all_file_templates(). Not sure how to test get_all_file_data() yet since relies on get_data() which uses synapser to download a file.