### PR TITLE
Fix silly config error

### DIFF
--- a/R/validate-by-file.R
+++ b/R/validate-by-file.R
@@ -31,7 +31,7 @@ validate_manifest <- function(manifest, template, annotations) {
   )
   complete_cols_manifest <- dccvalidator::check_cols_complete(
     manifest,
-    required_cols = config::get(required_cols$manifest),
+    required_cols = config::get("complete_columns")$manifest,
     success_msg = "All required columns are complete in the manifest",
     fail_msg = "Some required columns are incomplete in the manifest"
   )
@@ -78,7 +78,7 @@ validate_assay_meta <- function(assay, template, annotations) {
   )
   complete_cols_assay <- dccvalidator::check_cols_complete(
     assay,
-    required_cols = config::get(required_cols$assay),
+    required_cols = config::get("complete_columns")$assay,
     success_msg = "All required columns are complete in the assay metadata", # nolint
     fail_msg = "Some required columns are incomplete in the assay metadata" # nolint
   )
@@ -125,7 +125,7 @@ validate_biospecimen_meta <- function(biospecimen, template, annotations) {
   )
   complete_cols_biosp <- dccvalidator::check_cols_complete(
     biospecimen,
-    required_cols = config::get(required_cols$biospecimen),
+    required_cols = config::get("complete_columns")$biospecimen,
     success_msg = "All required columns are complete in the biospecimen metadata", # nolint
     fail_msg = "Some required columns are incomplete in the biospecimen metadata" # nolint
   )
@@ -173,7 +173,7 @@ validate_individual_meta <- function(individual, template, annotations) {
   )
   complete_cols_indiv <- dccvalidator::check_cols_complete(
     individual,
-    required_cols = config::get(required_cols$individual),
+    required_cols = config::get("complete_columns")$individual,
     success_msg = "All required columns are complete in the individual metadata", # nolint
     fail_msg = "Some required columns are incomplete in the individual metadata" # nolint
   )


### PR DESCRIPTION
`config::get()` was being used incorrectly, but my tests didn't catch it before. This fixes the usage.