### PR TITLE
Make file info table reactable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     ggplot2,
     golem,
     purrr,
+    reactable,
     reticulate,
     shiny,
     shinydashboard,

--- a/R/mod-study-overview.R
+++ b/R/mod-study-overview.R
@@ -41,7 +41,7 @@ study_overview_ui <- function(id) {
               tabPanel(
                 "File Details",
                 br(),
-                tableOutput(ns("data_details"))
+                reactable::reactableOutput(ns("data_details"))
               )
             )
           )
@@ -80,7 +80,7 @@ study_overview_server <- function(input, output, session,
     files_present <- unique(
       data$study_view$metadataType[
         !is.na(data$study_view$metadataType)
-        ]
+      ]
     )
     if (length(files_present) > 0) {
       updateSelectInput(
@@ -138,12 +138,60 @@ study_overview_server <- function(input, output, session,
 
   observeEvent(input$file_to_summarize, {
     if (input$file_to_summarize != "") {
-      data_index <- which(data$study_view$metadataType == input$file_to_summarize)
+      data_index <- which(
+        data$study_view$metadataType == input$file_to_summarize
+      )
       output$datafilevisdat <- renderPlot({
         visualize_data_types(data$study_view$file_data[[data_index]])
       })
-      output$data_details <- renderTable({
-        data_summary(data$study_view$file_data[[data_index]])
+      output$data_details <- reactable::renderReactable({
+        reactable::reactable(
+          data_summary(data$study_view$file_data[[data_index]]),
+          highlight = TRUE,
+          searchable = TRUE,
+          resizable = TRUE,
+          columns = list(
+            variable = reactable::colDef(
+              name = "Variable",
+              width = 125
+            ),
+            type = reactable::colDef(
+              name = "Type",
+              width = 75
+            ),
+            missing = reactable::colDef(
+              name = "Missing",
+              maxWidth = 75
+            ),
+            complete = reactable::colDef(
+              name = "Complete",
+              maxWidth = 75
+            ),
+            n = reactable::colDef(
+              name = "n",
+              maxWidth = 75
+            ),
+            min = reactable::colDef(
+              name = "Min",
+              maxWidth = 75
+            ),
+            max = reactable::colDef(
+              name = "Max",
+              maxWidth = 75
+            ),
+            empty = reactable::colDef(
+              name = "# Empty",
+              maxWidth = 75
+            ),
+            n_unique = reactable::colDef(
+              name = "# Unique",
+              maxWidth = 75
+            ),
+            value_occurrence = reactable::colDef(
+              name = "Value (# Occurrences)"
+            )
+          )
+        )
       })
     }
   })

--- a/man/num_individuals.Rd
+++ b/man/num_individuals.Rd
@@ -4,8 +4,10 @@
 \alias{num_individuals}
 \title{Get number of individuals}
 \usage{
-num_individuals(study_view, meta_types = c("manifest", "individual",
-  "biospecimen"))
+num_individuals(
+  study_view,
+  meta_types = c("manifest", "individual", "biospecimen")
+)
 }
 \arguments{
 \item{study_view}{The file view for a study, with the

--- a/man/num_specimens.Rd
+++ b/man/num_specimens.Rd
@@ -4,8 +4,7 @@
 \alias{num_specimens}
 \title{Get number of specimens}
 \usage{
-num_specimens(study_view, meta_types = c("manifest", "biospecimen",
-  "assay"))
+num_specimens(study_view, meta_types = c("manifest", "biospecimen", "assay"))
 }
 \arguments{
 \item{study_view}{The file view for a study, with the

--- a/renv.lock
+++ b/renv.lock
@@ -605,6 +605,20 @@
       "Repository": "CRAN",
       "Hash": "ed95895886dab6d2a584da45503555da"
     },
+    "reactR": {
+      "Package": "reactR",
+      "Version": "0.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "337cf76c8a0a122af9971339c0a9e66c"
+    },
+    "reactable": {
+      "Package": "reactable",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b4da71126a5d50e16a319d4f83e29d2f"
+    },
     "readr": {
       "Package": "readr",
       "Version": "1.3.1",


### PR DESCRIPTION
Title says it all. Reactable table is searchable and looks nicer. I did some hard-coding of column widths, which is somewhat undesired, but the default widths were inadequate. Instead, I made the table columns resizeable in case the hard-coded widths are too small/large for a person's taste.