### PR TITLE
Swap order of biospecimen and assay when checking specimenIDs

### DIFF
--- a/R/validate-by-study.R
+++ b/R/validate-by-study.R
@@ -80,10 +80,10 @@ validate_study <- function(study_table, annotations, syn) {
       )
       if ("biospecimen" %in% study_table$metadataType) {
         assay_biosp_ids <- dccvalidator::check_specimen_ids_match(
-          study_table$file_data[[file_indices$assay]],
           study_table$file_data[[file_indices$biospecimen]],
-          "assay",
+          study_table$file_data[[file_indices$assay]],
           "biospecimen",
+          "assay",
           bidirectional = FALSE
         )
         assay_results[["assay_biosp_ids"]] <- assay_biosp_ids


### PR DESCRIPTION
We want biospecimen to come first in the function call so that we return specimenIDs that are missing from the biospecimen file but present in the assay metadata file (see [here](https://github.com/Sage-Bionetworks/dccvalidator/blob/e9ae171c2166d5940576103f9d995e9ca17a87d7/R/app-server.R#L252-L260) in dccvalidator).