### PR TITLE
Get annotations as dccvalidator does

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     config,
     dplyr,
     ggplot2,
+    glue,
     golem,
     purrr,
     reactable,

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -36,7 +36,11 @@ app_server <- function(input, output, session) {
     )
 
     # Download annotation definitions
-    annotations <- dccvalidator::get_synapse_annotations(syn = syn)
+    annotations <- purrr::map_dfr(
+      config::get("annotations_table"),
+      dccvalidator::get_synapse_annotations,
+      syn = syn
+    )
 
     # Should be in config
     fileview_id <- config::get("consortium_fileview")

--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,6 @@ default:
   annotations_table: "syn10242922"
   teams:
     - "3346847"
-    - "273957"
   templates:
     manifest_template: "syn20820080"
     individual_templates:
@@ -32,6 +31,9 @@ default:
 
 amp-ad:
   consortium_fileview: "syn21448475"
+  annotations_table:
+    - "syn10242922"
+    - "syn21459391"
   teams:
     - "3346847"
   templates:


### PR DESCRIPTION
Fixes #31.

Gets annotations the same way dccvalidator does, with multiple annotation tables allowed in the config. Updates the amp-ad annotation tables in config.