### PR TITLE
Complicated fix to already complicated date tests

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -26,17 +26,32 @@ test_that("get_most_recent_time gets the most recent time", {
     as.POSIXct(strptime("2019-11-03 8:45:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC")
   )
   res1 <- get_most_recent_time(times1)
-  res2 <- get_most_recent_time(times2)
-  res3 <- get_most_recent_time(times3)
-  res4 <- get_most_recent_time(times4)
-  res5 <- get_most_recent_time(times5)
-  res6 <- get_most_recent_time(times6)
+  res2 <- get_most_recent_time(unclass(times2))
+  res3 <- get_most_recent_time(unclass(times3))
+  res4 <- get_most_recent_time(unclass(times4))
+  res5 <- get_most_recent_time(unclass(times5))
+  res6 <- get_most_recent_time(unclass(times6))
   expect_equal(res1, NULL)
-  expect_equal(res2, as.POSIXct(strptime("2019-12-15 01:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))
-  expect_equal(res3, as.POSIXct(strptime("2019-12-15 01:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))
-  expect_equal(res4, as.POSIXct(strptime("2019-12-15 01:30:01", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))
-  expect_equal(res5, as.POSIXct(strptime("2019-12-15 16:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))
-  expect_equal(res6, as.POSIXct(strptime("2019-12-04 10:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))
+  expect_equal(
+    res2,
+    unclass(as.POSIXct(strptime("2019-12-15 01:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))
+  )
+  expect_equal(
+    res3,
+    unclass(as.POSIXct(strptime("2019-12-15 01:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))[1]
+  )
+  expect_equal(
+    res4,
+    unclass(as.POSIXct(strptime("2019-12-15 01:30:01", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))[1]
+  )
+  expect_equal(
+    res5,
+    unclass(as.POSIXct(strptime("2019-12-15 16:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))[1]
+  )
+  expect_equal(
+    res6,
+    unclass(as.POSIXct(strptime("2019-12-04 10:30:00", "%Y-%m-%d %H:%M:%S"), tz = "UTC"))[1]
+  )
 })
 
 test_that("get_study_table_latest only filters metadata files", {


### PR DESCRIPTION
Fixes #35, sort of.

My tests for finding the most recent date were failing, but it appears to be working fine in the app. I believe the problem is with how I structured the tests. In short, I fixed them so they work correctly now, but given time in the future, a better way of dealing with time would be ideal.

Side note: tried using lubridate, but the date and time was off by a bit. Sticking with POSIXct seemed to work better.