### PR TITLE
Update file reading to use readr package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     golem,
     purrr,
     reactable,
+    readr,
     reticulate,
     shiny,
     shinyBS,

--- a/R/get-all-file-data.R
+++ b/R/get-all-file-data.R
@@ -41,20 +41,10 @@ get_data <- function(id, meta_type, syn) {
   file_info <- syn$get(id)
 
   if (meta_type == "manifest") {
-    data <- utils::read.table(
-      file_info$path,
-      sep = "\t",
-      header = TRUE,
-      na.strings = "",
-      stringsAsFactors = FALSE
-    )
+    data <- readr::read_tsv(file_info$path)
   } else {
-    data <- utils::read.csv(
-      file_info$path,
-      na.strings = "",
-      stringsAsFactors = FALSE
-    )
+    data <- readr::read_csv(file_info$path)
   }
 
-  return(tibble::as_tibble(data))
+  return(data)
 }


### PR DESCRIPTION
Fixes an issue [here](https://github.com/Sage-Bionetworks/dccvalidator/issues/274) where an empty template was uploaded through dccvalidator and caused dccmonitor to crash.

For some reason this isn't a problem if the files are read in with the `readr` package versus the base `read.csv()` and `read.table()` (even if the data frames are changed to tibbles). Jury still out on what is so special about `readr` that it doesn't cause the crash.