### PR TITLE
update biospecimen config args

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -75,7 +75,8 @@ pec:
       human: "syn20781820"
       animal: "syn21053116"
     biospecimen_templates:
-      general: "syn20768131"
+      animal model: "syn20768131"
+      human: "syn20768131"
     assay_templates:
       wholeGenomeSeq: "syn20980993"
       rnaSeq: "syn20768650"


### PR DESCRIPTION
I updated the config for dccvalidator and am pushing the same change here to deal with the explicit call out for biospecimen file type.