### PR TITLE
Update annotations instructions based on issue with old metadata

### DIFF
--- a/R/mod-edit-annotations.R
+++ b/R/mod-edit-annotations.R
@@ -11,11 +11,12 @@ edit_annotations_ui <- function(id) {
       h4("Instructions"),
       tags$ol(
         # nolint start
-        tags$li("Click on 'Get Annotations' to join all metadata to the manifest."),
+        tags$li("Click on 'Get Annotations' to join all metadata to the manifest. See note below."),
         tags$li("Select the desired annotation columns and verify annotations do not contain PII/PHI."),
         tags$li("Below the annotations table, give the name to download the file as and click on 'Download' to download the annotations as a csv file locally.")
         # nolint end
       ),
+      p("Note: All metadata files listed in the table above are joined to the manifest. Verify that only files relevant to the current data release are present."),
       dccvalidator::with_busy_indicator_ui(
         actionButton(ns("get_annots"), "Get annotations")
       ),


### PR DESCRIPTION
Quick update to add a note about verifying that only the relevant metadata files are present. If metadata files from old releases are present, then irrelevant annotations will be joined to the current annotations.