### PR TITLE
Upload annotations to Synapse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccmonitor
 Title: Monitor Data Validation
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     c(person(given = "Nicole",
              family = "Kauer",

--- a/R/app-server.R
+++ b/R/app-server.R
@@ -44,6 +44,15 @@ app_server <- function(input, output, session) {
     )
 
     if (inherits(membership, "check_pass")) {
+      # Add folder to upload annotations to if doesn't exist already
+      annots_folder <- try({
+        new_folder <- synapse$Folder(
+          name = user$userName,
+          parent = config::get("annotations_storage")
+          )
+        syn$store(new_folder)
+      })
+
       # Download annotation definitions
       annotations <- purrr::map_dfr(
         config::get("annotations_table"),
@@ -74,7 +83,9 @@ app_server <- function(input, output, session) {
           session = getDefaultReactiveDomain(),
           fileview = view,
           annotations = annotations,
-          syn = syn
+          annots_folder = annots_folder,
+          syn = syn,
+          synapseclient = synapse
         )
       })
     }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This package is intended to assist Sage Bionetworks data curators to check the status of metadata and documentation files uploaded via the [dccvalidator](https://sage-bionetworks.github.io/dccvalidator/) shiny application. The dccmonitor package contains functions to gather validation information. Optionally, the included Shiny application can be used to view the results.
 
-**Note:** The application takes time to fully populate the validation information and currently does not have a progress indicator. The application will initialize the study boxes after checking for team membership and gathering the studies represented in the `consortium_fileview` (see Customization for details on this file view). After this, the application will populate the study boxes after the validation checks have run for all represented studies.
-
 ## Requirements
 
 dccmonitor uses the reticulate package with the [Synapse Python Client](https://github.com/Sage-Bionetworks/synapsePythonClient). See the [reticulate documentation](https://rstudio.github.io/reticulate/#python-version) for more information on setting up reticulate to work with your local Python environment. Additionally, see the [Synapse Python Client](https://github.com/Sage-Bionetworks/synapsePythonClient) for installation instructions. The Synapse Python Client should be installed in the same Python environment used by reticulate.
@@ -54,6 +52,7 @@ A configuration file is required for the application to behave correctly. Create
 Of the configuration options, only two are specific to dccmonitor while the rest are used to customize the dccvalidator checks. The dccmonitor specific configurations are:
 
 - `teams`: Synapse administration team ID. The app data should only be accessible to curators with admin privileges.
+- `annotations_storage`: Synapse folder ID for storing annotation csv files created in the. The folder should only be accessible to curators with admin privileges.
 - `consortium_fileview`: Synapse file view ID. A Synapse file view that shows all the files in the `parent` folder (this is the folder that dccvalidator uploads metadata and documentation files to), along with their annotations. The file view should include the columns: id, name, createdOn, createdBy, modifiedOn, currentVersion, study, metadataType, species, assay. Note that the following file-specific annotations are required for dccmonitor to function properly:
     - documentation: study
     - manifest: study, metadataType = manifest
@@ -71,15 +70,5 @@ A brief overview of the dccvalidator specific configurations are below, but more
   
 ### Validation Checks
 
-dccmonitor uses dccvalidator to validate the metadata and manifest files. Currently, this is done in a set of functions that are updated to mirror the most recent version of the dccvalidator application. To customize the validation checks performed, the following functions would need to be changed:
+dccmonitor uses the [dccvalidator's `check_all()`](https://github.com/Sage-Bionetworks/dccvalidator/blob/master/R/check-all.R) to validate the metadata and manifest files. Currently, there is not a simple way to change the validation checks that are done.
 
-#### validate-by-study.R
-
-- `validate_study()`: handles the validation of an individual study, sending files on to be validated by themselves and doing validation checks across files.
-
-#### validate-by-file.R
-
-- `validate_manifest()`: validation checks specific to the manifest.
-- `validate_individual_meta()`: validation checks specific to the individual metadata.
-- `validate_biospecimen_meta()`: validation checks specific to the biospecimen metadata.
-- `validate_assay_meta()`: validation checks specific to the assay metadata.

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 default:
   consortium_fileview: "syn21027019"
+  annotations_storage: "syn21703007"
   annotations_table: "syn10242922"
   annotations_link: "https://shinypro.synapse.org/users/nsanati/annotationUI/"
   teams:
@@ -34,6 +35,7 @@ default:
 amp-ad:
   annotations_link: "https://shinypro.synapse.org/users/kwoo/amp-ad-metadata-dictionary/"
   consortium_fileview: "syn21448475"
+  annotations_storage: "syn21698384"
   annotations_table:
     - "syn10242922"
     - "syn21459391"

--- a/man/edit_annotations_server.Rd
+++ b/man/edit_annotations_server.Rd
@@ -4,7 +4,15 @@
 \alias{edit_annotations_server}
 \title{Edit annotations module server}
 \usage{
-edit_annotations_server(input, output, session, fileview)
+edit_annotations_server(
+  input,
+  output,
+  session,
+  fileview,
+  annots_folder,
+  syn,
+  synapseclient
+)
 }
 \arguments{
 \item{input}{Shiny input}
@@ -14,6 +22,12 @@ edit_annotations_server(input, output, session, fileview)
 \item{session}{Shiny session}
 
 \item{fileview}{The fileview for a specific study.}
+
+\item{annots_folder}{Synapse folder ID to store generated annotation csvs in.}
+
+\item{syn}{Synapse client object.}
+
+\item{synapseclient}{Synapse client.}
 }
 \description{
 Server function for the edit annotations module.

--- a/man/study_overview_server.Rd
+++ b/man/study_overview_server.Rd
@@ -4,7 +4,16 @@
 \alias{study_overview_server}
 \title{Server for the study overview module}
 \usage{
-study_overview_server(input, output, session, fileview, annotations, syn)
+study_overview_server(
+  input,
+  output,
+  session,
+  fileview,
+  annotations,
+  annots_folder,
+  syn,
+  synapseclient
+)
 }
 \arguments{
 \item{input}{Shiny input}
@@ -17,7 +26,11 @@ study_overview_server(input, output, session, fileview, annotations, syn)
 
 \item{annotations}{A dataframe of annotation definitions.}
 
+\item{annots_folder}{Synapse folder ID to store generated annotation csvs in.}
+
 \item{syn}{Synapse client object.}
+
+\item{synapseclient}{Synapse client.}
 }
 \description{
 Server for the study overview module.


### PR DESCRIPTION
Fixes #61, #66.

Changes:
- Adds annotations_storage to config for storing annotation files created in dccmonitor. Folder should be in the team's validation folder so it has the same permissions.
- Updates server to create a folder with the user name under parent config:annotations_storage.
- Adds needed params to send all the information needed to the edit_annotations mod.
- Changes from downloading the file locally (i.e. using a download handler to download to a desired local folder) to downloading as a temporary file and then uploading to Synapse under the user-named folder.
- Updates instructions/documentation in app, as well as in README to account for the new configs.
- Edits section about how the data is validated to reflect using dccvalidator's `check_all()`. Also removes the note about how the app looks like it's not working while it's loading. This is somewhat taken care of by the new UI.
- Update version.

Live version on shiny server under nkauer/dccmonitor-test. Uses test team: syn20818950.