### PR TITLE
Annot keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dccmonitor
 Title: Monitor Data Validation
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     c(person(given = "Nicole",
              family = "Kauer",

--- a/R/mod-edit-annotations.R
+++ b/R/mod-edit-annotations.R
@@ -12,7 +12,7 @@ edit_annotations_ui <- function(id) {
       # nolint start
       tags$ol(
         tags$li("Click on 'Get Annotations' to join all metadata to the manifest. See note below."),
-        tags$li("Select the desired annotation columns and verify annotations do not contain PII/PHI."),
+        tags$li("Select or deselect the desired annotation keys and verify annotations do not contain PII/PHI."),
         tags$li("Below the annotations table, give the name to download the file as and click on 'Download' to download the annotations as a csv file locally.")
       ),
       p("Note: All metadata files listed in the table above are joined to the manifest. Verify that only files relevant to the current data release are present."),

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Of the configuration options, only two are specific to dccmonitor while the rest
     - individual metadata: study, species, metadataType = individual
     - biospecimen metadata: study, species, metadataType = biospecimen
     - assay metadata: study, species, assay, metadataType = assay
+- `annotation_keys`: List of annotation keys that should **not** be included in annotations. These keys would be any that could be considered PHI/PII.
 
 A brief overview of the dccvalidator specific configurations are below, but more information can be found in the [dccvalidator documentation](https://sage-bionetworks.github.io/dccvalidator/articles/customizing-dccvalidator.html#configuration-options):
 

--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,9 @@ default:
   consortium_fileview: "syn21027019"
   annotations_table: "syn10242922"
   annotations_link: "https://shinypro.synapse.org/users/nsanati/annotationUI/"
+  annotation_keys:
+    - "age"
+    - "primaryDiagnosis"
   teams:
     - "3346847"
   templates:
@@ -37,6 +40,9 @@ amp-ad:
   annotations_table:
     - "syn10242922"
     - "syn21459391"
+  annotation_keys:
+    - "age"
+    - "primaryDiagnosis"
   teams:
     - "3346847"
   templates:
@@ -66,6 +72,9 @@ amp-ad:
 pec:
   annotations_table: "syn20981788"
   annotations_link: "https://www.synapse.org/#!Synapse:syn20729790"
+  annotation_keys:
+    - "age"
+    - "primaryDiagnosis"
   consortium_fileview: "syn21560413"
   teams:
     - "3328037"


### PR DESCRIPTION
Fixes #60.

Changes:
- Add new config annotation_keys for the disallowed keys.
- Auto-select all keys except those that are disallowed when populating the annotation key selector.
- Slightly update instruction language.