### PR TITLE
Add annotation storage folder for PEC again

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -67,6 +67,7 @@ amp-ad:
 
 pec:
   annotations_table: "syn20981788"
+  annotations_storage: "syn21759902"
   annotations_link: "https://www.synapse.org/#!Synapse:syn20729790"
   consortium_fileview: "syn21560413"
   teams:


### PR DESCRIPTION
Authored originally by @kelshmo

The branch the original change was added to is already merged. Doing this instead of re-merging the other branch.