### PR TITLE
Update config for MODEL-AD mouse species and template

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,7 +47,16 @@ amp-ad:
     - "primaryDiagnosis"
   teams:
     - "3346847"
+  species_list:
+    - "human"
+    - "drosophila"
+    - "MODEL-AD mouse model"
+    - "other mouse or animal model"
   templates:
+    individual_templates:
+      human: "syn12973254"
+      other mouse or animal model: "syn12973253"
+      MODEL-AD mouse model: "syn21084071"
     assay_templates:
       proteomics: "syn12973255"
       single cell RNAseq: "syn21018360"


### PR DESCRIPTION
For [this issue](https://github.com/Sage-Bionetworks/dccvalidator/issues/331). Once the dccvalidator is updated, dccmonitor needs updated.