### PR TITLE
Remove the extra AMP-AD annotations table

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,9 +41,7 @@ amp-ad:
   consortium_fileview: "syn21448475"
   samples_table: "syn21578908"
   annotations_storage: "syn21698384"
-  annotations_table:
-    - "syn10242922"
-    - "syn21459391"
+  annotations_table: "syn10242922"
   annotation_keys:
     - "age"
     - "primaryDiagnosis"


### PR DESCRIPTION
Remove extra AMP-AD annotations table from config. See [this PR for more info](https://github.com/Sage-Bionetworks/dccvalidator/pull/458).